### PR TITLE
Nzpmc 084/fix incorrect password error

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -149,6 +149,7 @@ export default {
                     .catch((error) => {
                         this.loginError = error.message
                     })
+                this.loading = false
                 onLogin(this.$apollo.provider.defaultClient)
             }
         },

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -94,7 +94,13 @@
                         </v-row>
                         <v-row>
                             <v-col class="text-right">
-                                <v-btn large color="primary" type="submit">
+                                <v-btn
+                                    large
+                                    color="primary"
+                                    type="submit"
+                                    :loading="loading"
+                                    :disabled="loading"
+                                >
                                     <v-icon left class="material-icons">
                                         login
                                     </v-icon>


### PR DESCRIPTION
**Issue**

The loading overlay remains forever after an incorrect password was entered.

**Solution**

Changed the value of the variable of loading to false after the page has stopped loading.

**Reviewers**

@matthewaptaylor 
