### PR TITLE
Nzpc 085/fix the ugly quiz selector

### DIFF
--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -54,69 +54,84 @@
                     </v-row>
                     <v-row>
                         <v-col class="col-12 text-center">
-                            <v-btn
-                                class="mr-3"
-                                @click="overlay = !overlay"
-                                large
-                                color="primary"
-                            >
-                                Start
-                                <v-icon right class="material-icons">
-                                    navigate_next
-                                </v-icon>
-                            </v-btn>
-                            <v-btn
-                                v-if="getLocalStorage('currentQuizID') != null"
-                                @click="continueQuiz()"
-                                large
-                                color="secondary"
-                                :disabled="!userQuizzes"
-                            >
-                                Continue
-                                <v-icon right class="material-icons">
-                                    navigate_next
-                                </v-icon>
-                            </v-btn>
-                            <v-overlay :value="overlay" align="center">
-                                <template v-for="(item, index) in userQuizzes">
-                                    <v-row
-                                        :key="index"
-                                        justify="center"
+                            <v-dialog v-model="dialog" width="500">
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-btn
                                         class="mr-3"
+                                        @click="overlay = !overlay"
+                                        large
+                                        color="primary"
+                                        v-bind="attrs"
+                                        v-on="on"
                                     >
-                                        <v-btn
-                                            v-if="item.startTime != null"
-                                            @click="continueQuiz(index)"
-                                            large
-                                            color="secondary"
-                                            class="mb-3"
-                                        >
-                                            Continue Quiz {{ index + 1 }}
-                                            <v-icon
-                                                right
-                                                class="material-icons"
-                                            >
-                                                navigate_next
-                                            </v-icon>
-                                        </v-btn>
-                                        <v-btn
-                                            v-else
-                                            @click="startQuiz(index)"
-                                            large
-                                            color="primary"
-                                            class="mb-3"
-                                        >
-                                            Quiz {{ index + 1 }}
-                                            <v-icon
-                                                right
-                                                class="material-icons"
-                                            >
-                                                navigate_next
-                                            </v-icon>
-                                        </v-btn>
-                                    </v-row>
+                                        Start
+                                        <v-icon right class="material-icons">
+                                            navigate_next
+                                        </v-icon>
+                                    </v-btn>
                                 </template>
-                            </v-overlay>
+                                <v-btn
+                                    v-if="
+                                        getLocalStorage('currentQuizID') != null
+                                    "
+                                    @click="continueQuiz()"
+                                    large
+                                    color="secondary"
+                                    :disabled="!userQuizzes"
+                                >
+                                    Continue
+                                    <v-icon right class="material-icons">
+                                        navigate_next
+                                    </v-icon>
+                                </v-btn>
+                                <!-- <v-overlay :value="overlay" align="center"> -->
+                                <v-card>
+                                    <v-toolbar color="primary" dark>
+                                        <h3>Quiz list</h3>
+                                    </v-toolbar>
+                                    <template
+                                        v-for="(item, index) in userQuizzes"
+                                    >
+                                        <v-row
+                                            :key="index"
+                                            justify="center"
+                                            class="mr-3"
+                                        >
+                                            <v-btn
+                                                v-if="item.startTime != null"
+                                                @click="continueQuiz(index)"
+                                                large
+                                                color="secondary"
+                                                class="mb-3"
+                                            >
+                                                Continue: {{ item.name }}
+                                                <v-icon
+                                                    right
+                                                    class="material-icons"
+                                                >
+                                                    navigate_next
+                                                </v-icon>
+                                            </v-btn>
+                                            <v-btn
+                                                v-else
+                                                @click="startQuiz(index)"
+                                                large
+                                                color="primary"
+                                                class="mb-3"
+                                            >
+                                                Quiz: {{ item.name }}
+                                                <v-icon
+                                                    right
+                                                    class="material-icons"
+                                                >
+                                                    navigate_next
+                                                </v-icon>
+                                            </v-btn>
+                                        </v-row>
+                                    </template>
+                                </v-card>
+                                <!-- </v-overlay> -->
+                            </v-dialog>
                         </v-col>
                     </v-row>
                 </v-card>

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -84,7 +84,6 @@
                                         navigate_next
                                     </v-icon>
                                 </v-btn>
-                                <!-- <v-overlay :value="overlay" align="center"> -->
                                 <v-card>
                                     <v-toolbar color="primary" dark>
                                         <h3>Quiz list</h3>
@@ -96,16 +95,15 @@
                                             <v-row
                                                 :key="index"
                                                 justify="center"
-                                                class="mr-3"
                                             >
-                                                <v-btn
+                                                <v-list-item
                                                     v-if="
                                                         item.startTime != null
                                                     "
                                                     @click="continueQuiz(index)"
                                                     large
                                                     color="secondary"
-                                                    class="mb-3"
+                                                    class="my-3"
                                                 >
                                                     Continue: {{ item.name }}
                                                     <v-icon
@@ -114,27 +112,26 @@
                                                     >
                                                         navigate_next
                                                     </v-icon>
-                                                </v-btn>
-                                                <v-btn
+                                                </v-list-item>
+                                                <v-list-item
                                                     v-else
                                                     @click="startQuiz(index)"
                                                     large
                                                     color="primary"
                                                     class="mb-3"
                                                 >
-                                                    Quiz: {{ item.name }}
+                                                    {{ item.name }}
                                                     <v-icon
                                                         right
                                                         class="material-icons"
                                                     >
                                                         navigate_next
                                                     </v-icon>
-                                                </v-btn>
+                                                </v-list-item>
                                             </v-row>
                                         </template>
                                     </v-container>
                                 </v-card>
-                                <!-- </v-overlay> -->
                             </v-dialog>
                         </v-col>
                     </v-row>

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -89,46 +89,50 @@
                                     <v-toolbar color="primary" dark>
                                         <h3>Quiz list</h3>
                                     </v-toolbar>
-                                    <template
-                                        v-for="(item, index) in userQuizzes"
-                                    >
-                                        <v-row
-                                            :key="index"
-                                            justify="center"
-                                            class="mr-3"
+                                    <v-container>
+                                        <template
+                                            v-for="(item, index) in userQuizzes"
                                         >
-                                            <v-btn
-                                                v-if="item.startTime != null"
-                                                @click="continueQuiz(index)"
-                                                large
-                                                color="secondary"
-                                                class="mb-3"
+                                            <v-row
+                                                :key="index"
+                                                justify="center"
+                                                class="mr-3"
                                             >
-                                                Continue: {{ item.name }}
-                                                <v-icon
-                                                    right
-                                                    class="material-icons"
+                                                <v-btn
+                                                    v-if="
+                                                        item.startTime != null
+                                                    "
+                                                    @click="continueQuiz(index)"
+                                                    large
+                                                    color="secondary"
+                                                    class="mb-3"
                                                 >
-                                                    navigate_next
-                                                </v-icon>
-                                            </v-btn>
-                                            <v-btn
-                                                v-else
-                                                @click="startQuiz(index)"
-                                                large
-                                                color="primary"
-                                                class="mb-3"
-                                            >
-                                                Quiz: {{ item.name }}
-                                                <v-icon
-                                                    right
-                                                    class="material-icons"
+                                                    Continue: {{ item.name }}
+                                                    <v-icon
+                                                        right
+                                                        class="material-icons"
+                                                    >
+                                                        navigate_next
+                                                    </v-icon>
+                                                </v-btn>
+                                                <v-btn
+                                                    v-else
+                                                    @click="startQuiz(index)"
+                                                    large
+                                                    color="primary"
+                                                    class="mb-3"
                                                 >
-                                                    navigate_next
-                                                </v-icon>
-                                            </v-btn>
-                                        </v-row>
-                                    </template>
+                                                    Quiz: {{ item.name }}
+                                                    <v-icon
+                                                        right
+                                                        class="material-icons"
+                                                    >
+                                                        navigate_next
+                                                    </v-icon>
+                                                </v-btn>
+                                            </v-row>
+                                        </template>
+                                    </v-container>
                                 </v-card>
                                 <!-- </v-overlay> -->
                             </v-dialog>


### PR DESCRIPTION
**Issue**

The start button in `Welcome.vue` displays an overlay, which can't be closed.

**Solution**

Switched overlay for `v-dialog` and switched buttons for `v-list-item` to make it look nicer.


**Risk**

There are probably some unused variables and functions that are no longer needed after removing overlay, which are still inside `Welcome.vue`.


