### PR TITLE
Nzmpc 087/fix admin question UI

### DIFF
--- a/src/components/Admin/Quiz/QuizAdminQuestion.vue
+++ b/src/components/Admin/Quiz/QuizAdminQuestion.vue
@@ -406,10 +406,11 @@ export default {
         },
 
         saveQuestion() {
-            // Creates a quiz
+            // Saves changes to Quiz
             this.success = null
             this.error = null
             this.questionFormLoading = true
+            this.originalQuestion = this.questionDetails.question
 
             this.$apollo
                 .mutate({

--- a/src/components/DisplayText.vue
+++ b/src/components/DisplayText.vue
@@ -2,6 +2,14 @@
     <latex :content="parsed" style="margin-bottom: -16px" />
 </template>
 
+<style>
+/* Sizing will depend on screen size*/
+img {
+    width: 100%;
+    height: 100%;
+}
+</style>
+
 <script>
 import showdown from 'showdown'
 


### PR DESCRIPTION
**Issue**

Admin page save button would remain usable after the initial save.
Markdown image isn't formatted.

**Solution**

One of the comparison variables wasn't changed after each save, so this was added in the saveQuestion method.

Added Style for image in the DisplayText.vue file 

